### PR TITLE
Use add auth param to add login hint

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -19,7 +19,6 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
 {
     protected ?JweDecryptInterface $jweDecrypter;
     protected ?OpenIDConfiguration $openIDConfiguration;
-    protected ?string $loginHint = null;
 
     public function __construct(
         ?string $providerUrl = null,
@@ -122,12 +121,11 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
      */
     public function setLoginHint(?string $loginHint = null): void
     {
-        $this->loginHint = $loginHint;
+        $this->addAuthParam(['login_hint' => $loginHint]);
     }
 
     /**
      * Overwrite the redirect method to a redirect method of Laravel.
-     * And add login_hint when redirecting to the authorization endpoint.
      * Sometimes the error 'Cannot modify header information - headers already sent' was thrown.
      * By using HttpResponseException, laravel will return the given response.
      * @param string $url
@@ -136,14 +134,6 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
      */
     public function redirect($url): void
     {
-        $authorizationEndpoint = $this->getAuthorizationEndpoint();
-        if (
-            !empty($this->loginHint)
-            && str_starts_with($url, $authorizationEndpoint)
-        ) {
-            $url .= "&" . http_build_query(['login_hint' => $this->loginHint]);
-        }
-
         throw new HttpResponseException(new RedirectResponse($url));
     }
 


### PR DESCRIPTION
After seeing https://github.com/jumbojett/OpenID-Connect-PHP/pull/197 again I modified the code to use the available function `addAuthParam()` instead of having a custom property and building the redirect url.

Already tested by:
https://github.com/minvws/nl-rdo-openid-connect-php-laravel/blob/871c31ff49eb234b40f95187dc8e2fe44b7e94b4/tests/Feature/Http/Controllers/LoginControllerTest.php#L38-L50