### PR TITLE
Update base url of openid configuration loader

### DIFF
--- a/src/OpenIDConfiguration/OpenIDConfigurationLoader.php
+++ b/src/OpenIDConfiguration/OpenIDConfigurationLoader.php
@@ -38,11 +38,11 @@ class OpenIDConfigurationLoader
     {
         $url = $this->getOpenIDConfigurationUrl();
 
-        $pendingRequest = Http::baseUrl($url);
-        if (!$this->tlsVerify) {
-            $pendingRequest->withoutVerifying();
-        }
-        $response = $pendingRequest->get($url);
+        $response = Http::baseUrl($this->issuer)
+            ->when(!$this->tlsVerify, function ($pendingRequest) {
+                return $pendingRequest->withoutVerifying();
+            })
+            ->get($url);
 
         if (!$response->successful()) {
             throw new OpenIDConfigurationLoaderException(
@@ -97,6 +97,6 @@ class OpenIDConfigurationLoader
 
     protected function getOpenIDConfigurationUrl(): string
     {
-        return $this->issuer . '/.well-known/openid-configuration';
+        return '/.well-known/openid-configuration';
     }
 }

--- a/tests/Feature/OpenIDConfiguration/OpenIDConfigurationLoaderTest.php
+++ b/tests/Feature/OpenIDConfiguration/OpenIDConfigurationLoaderTest.php
@@ -118,7 +118,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
 
             $context = $exception->context();
             $this->assertSame("https://provider.rdobeheer.nl", $context['issuer']);
-            $this->assertSame("https://provider.rdobeheer.nl/.well-known/openid-configuration", $context['url']);
+            $this->assertSame("/.well-known/openid-configuration", $context['url']);
             $this->assertSame(400, $context['response_status_code']);
         }
     }
@@ -137,7 +137,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
 
             $context = $exception->context();
             $this->assertSame("https://provider.rdobeheer.nl", $context['issuer']);
-            $this->assertSame("https://provider.rdobeheer.nl/.well-known/openid-configuration", $context['url']);
+            $this->assertSame("/.well-known/openid-configuration", $context['url']);
             $this->assertSame(500, $context['response_status_code']);
         }
     }
@@ -156,7 +156,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
 
             $context = $exception->context();
             $this->assertSame("https://provider.rdobeheer.nl", $context['issuer']);
-            $this->assertSame("https://provider.rdobeheer.nl/.well-known/openid-configuration", $context['url']);
+            $this->assertSame("/.well-known/openid-configuration", $context['url']);
             $this->assertSame(200, $context['response_status_code']);
             $this->assertSame('', $context['response_body']);
         }
@@ -176,7 +176,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
 
             $context = $exception->context();
             $this->assertSame("https://provider.rdobeheer.nl", $context['issuer']);
-            $this->assertSame("https://provider.rdobeheer.nl/.well-known/openid-configuration", $context['url']);
+            $this->assertSame("/.well-known/openid-configuration", $context['url']);
             $this->assertSame(200, $context['response_status_code']);
             $this->assertSame('some invalid response', $context['response_body']);
         }


### PR DESCRIPTION
This will set the issuer as the base url and not set an absolute url twice.