### PR TITLE
Support private key JWT token endpoint authentication

### DIFF
--- a/config/oidc.php
+++ b/config/oidc.php
@@ -21,6 +21,24 @@ return [
     'client_secret' => env('OIDC_CLIENT_SECRET', ''),
 
     /**
+     * Configuration for the token authentication.
+     */
+    'client_authentication' => [
+
+        /**
+         * When you want to use `private_key_jwt` client authentication then you can specify the path to the private key.
+         */
+        'signing_private_key_path' => env('OIDC_SIGNING_PRIVATE_KEY_PATH', ''),
+
+        /**
+         * When you want to use `private_key_jwt` client authentication then you can specify the signing algorithm.
+         * For a list of supported algorithms see https://tools.ietf.org/html/rfc7518#section-3.1
+         */
+        'signing_algorithm' => env('OIDC_SIGNING_ALGORITHM', 'RS256'),
+        
+    ],
+
+    /**
      * Only needed when response of user info endpoint is encrypted.
      * This is the path to the JWE decryption key.
      *

--- a/config/oidc.php
+++ b/config/oidc.php
@@ -24,7 +24,6 @@ return [
      * Configuration for the token authentication.
      */
     'client_authentication' => [
-
         /**
          * When you want to use `private_key_jwt` client authentication then you can specify the path to the private key.
          */

--- a/config/oidc.php
+++ b/config/oidc.php
@@ -28,7 +28,7 @@ return [
         /**
          * When you want to use `private_key_jwt` client authentication then you can specify the path to the private key.
          */
-        'signing_private_key_path' => env('OIDC_SIGNING_PRIVATE_KEY_PATH', ''),
+        'signing_private_key_path' => env('OIDC_SIGNING_PRIVATE_KEY_PATH'),
 
         /**
          * When you want to use `private_key_jwt` client authentication then you can specify the signing algorithm.

--- a/config/oidc.php
+++ b/config/oidc.php
@@ -35,7 +35,17 @@ return [
          * For a list of supported algorithms see https://tools.ietf.org/html/rfc7518#section-3.1
          */
         'signing_algorithm' => env('OIDC_SIGNING_ALGORITHM', 'RS256'),
-        
+
+        /**
+         * When you want to use `private_key_jwt` client authentication then need
+         * to specify the available signature algorithms.
+         *
+         * The input is used for the AlgorithmManager and should be a list of class names.
+         * See https://web-token.spomky-labs.com/the-components/algorithm-management-jwa
+         */
+        'signature_algorithms' => [
+            \Jose\Component\Signature\Algorithm\RS256::class,
+        ],
     ],
 
     /**

--- a/config/oidc.php
+++ b/config/oidc.php
@@ -45,6 +45,12 @@ return [
         'signature_algorithms' => [
             \Jose\Component\Signature\Algorithm\RS256::class,
         ],
+
+        /**
+         * Token lifetime in seconds, used to set the expiration time of the JWT.
+         * This is used when you are using `private_key_jwt` client authentication.
+         */
+        'token_lifetime_in_seconds' => 60,
     ],
 
     /**

--- a/src/OpenIDConnectServiceProvider.php
+++ b/src/OpenIDConnectServiceProvider.php
@@ -126,9 +126,6 @@ class OpenIDConnectServiceProvider extends ServiceProvider
 
             $signingPrivateKeyPath = $app['config']->get('oidc.client_authentication.signing_private_key_path');
             if (!empty($signingPrivateKeyPath)) {
-                // Explicit allow of private_key_jwt
-                $oidc->setTokenEndpointAuthMethodsSupported(['private_key_jwt']);
-
                 $algorithms = $this->parseSignatureAlgorithms($app['config']);
                 $singingAlgorithm = $app['config']->get('oidc.client_authentication.signing_algorithm');
                 $signingPrivateKey = JWKFactory::createFromKeyFile($signingPrivateKeyPath);
@@ -140,7 +137,10 @@ class OpenIDConnectServiceProvider extends ServiceProvider
                     signatureAlgorithm: $singingAlgorithm,
                     serializer: new CompactSerializer()
                 );
+
+                // Set private key JWT generator and explicit allow of private_key_jwt
                 $oidc->setPrivateKeyJwtGenerator($privateKeyJwtBuilder);
+                $oidc->setTokenEndpointAuthMethodsSupported(['private_key_jwt']);
             }
 
             return $oidc;

--- a/src/OpenIDConnectServiceProvider.php
+++ b/src/OpenIDConnectServiceProvider.php
@@ -122,12 +122,12 @@ class OpenIDConnectServiceProvider extends ServiceProvider
 
             $oidc->setTlsVerify($app['config']->get('oidc.tls_verify'));
 
-            $signingPrivateKeyPath = $app['config']->get('client_authentication.signing_private_key_path');
+            $signingPrivateKeyPath = $app['config']->get('oidc.client_authentication.signing_private_key_path');
             if (!empty($signingPrivateKeyPath)) {
                 // Explicit allow of private_key_jwt
                 $oidc->setTokenEndpointAuthMethodsSupported(['private_key_jwt']);
 
-                $signingAlgorithm = $app['config']->get('client_authentication.signing_algorithm');
+                $signingAlgorithm = $app['config']->get('oidc.client_authentication.signing_algorithm');
 
                 $privateKeyJwtBuilder = new PrivateKeyJWTBuilder(
                     clientId: $clientId,

--- a/src/OpenIDConnectServiceProvider.php
+++ b/src/OpenIDConnectServiceProvider.php
@@ -127,15 +127,17 @@ class OpenIDConnectServiceProvider extends ServiceProvider
             $signingPrivateKeyPath = $app['config']->get('oidc.client_authentication.signing_private_key_path');
             if (!empty($signingPrivateKeyPath)) {
                 $algorithms = $this->parseSignatureAlgorithms($app['config']);
-                $singingAlgorithm = $app['config']->get('oidc.client_authentication.signing_algorithm');
                 $signingPrivateKey = JWKFactory::createFromKeyFile($signingPrivateKeyPath);
+                $singingAlgorithm = $app['config']->get('oidc.client_authentication.signing_algorithm');
+                $tokenLifetimeInSeconds = $app['config']->get('oidc.client_authentication.token_lifetime_in_seconds');
 
                 $privateKeyJwtBuilder = new PrivateKeyJWTBuilder(
                     clientId: $clientId,
                     jwsBuilder: new JWSBuilder(new AlgorithmManager($algorithms)),
                     signatureKey: $signingPrivateKey,
                     signatureAlgorithm: $singingAlgorithm,
-                    serializer: new CompactSerializer()
+                    serializer: new CompactSerializer(),
+                    tokenLifetimeInSeconds: $tokenLifetimeInSeconds,
                 );
 
                 // Set private key JWT generator and explicit allow of private_key_jwt

--- a/src/OpenIDConnectServiceProvider.php
+++ b/src/OpenIDConnectServiceProvider.php
@@ -122,15 +122,18 @@ class OpenIDConnectServiceProvider extends ServiceProvider
 
             $oidc->setTlsVerify($app['config']->get('oidc.tls_verify'));
 
-            if (!empty($app['config']->get('client_authentication.signing_private_key_path'))) {
+            $signingPrivateKeyPath = $app['config']->get('client_authentication.signing_private_key_path');
+            if (!empty($signingPrivateKeyPath)) {
                 // Explicit allow of private_key_jwt
                 $oidc->setTokenEndpointAuthMethodsSupported(['private_key_jwt']);
 
+                $signingAlgorithm = $app['config']->get('client_authentication.signing_algorithm');
+
                 $privateKeyJwtBuilder = new PrivateKeyJWTBuilder(
                     clientId: $clientId,
-                    jwsBuilder: new JWSBuilder(new AlgorithmManager([config('client_authentication.signing_algorithm')])),
-                    signatureKey: $app['config']->get('client_authentication.signing_private_key_path'),
-                    signatureAlgorithm: $app['config']->get('client_authentication.signing_algorithm'),
+                    jwsBuilder: new JWSBuilder(new AlgorithmManager([$signingAlgorithm])),
+                    signatureKey: $signingPrivateKeyPath,
+                    signatureAlgorithm: $signingAlgorithm,
                     serializer: new CompactSerializer()
                 );
                 $oidc->setPrivateKeyJwtGenerator($privateKeyJwtBuilder);

--- a/src/Services/JWS/PrivateKeyJWTBuilder.php
+++ b/src/Services/JWS/PrivateKeyJWTBuilder.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MinVWS\OpenIDConnectLaravel\Services\JWS;
+
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+
+class PrivateKeyJWTBuilder
+{
+    public function __construct(
+        protected string $clientId,
+        protected JWSBuilder $jwsBuilder,
+        protected JWK $signatureKey,
+        protected string $signatureAlgorithm,
+        protected CompactSerializer $serializer
+    ) {
+    }
+
+    public function __invoke(string $audience): string
+    {
+        return $this->buildJws($this->getPayload($audience));
+    }
+
+    protected function getPayload(string $audience): string
+    {
+        return json_encode([
+            'iat' => time(),
+            'nbf' => time(),
+            'exp' => time() + 300,
+            'iss' => $this->clientId,
+            'sub' => $this->clientId,
+            'aud' => $audience,
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    protected function buildJws(string $payload): string
+    {
+        $jws = $this->jwsBuilder
+            ->create()
+            ->withPayload($payload)
+            ->addSignature($this->signatureKey, ['alg' => $this->signatureAlgorithm])
+            ->build();
+
+        return $this->serializer->serialize($jws, 0);
+    }
+}

--- a/src/Services/JWS/PrivateKeyJWTBuilder.php
+++ b/src/Services/JWS/PrivateKeyJWTBuilder.php
@@ -6,7 +6,7 @@ namespace MinVWS\OpenIDConnectLaravel\Services\JWS;
 
 use Jose\Component\Core\JWK;
 use Jose\Component\Signature\JWSBuilder;
-use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Component\Signature\Serializer\JWSSerializer;
 
 class PrivateKeyJWTBuilder
 {
@@ -15,7 +15,7 @@ class PrivateKeyJWTBuilder
         protected JWSBuilder $jwsBuilder,
         protected JWK $signatureKey,
         protected string $signatureAlgorithm,
-        protected CompactSerializer $serializer
+        protected JWSSerializer $serializer
     ) {
     }
 

--- a/src/Services/JWS/PrivateKeyJWTBuilder.php
+++ b/src/Services/JWS/PrivateKeyJWTBuilder.php
@@ -15,7 +15,8 @@ class PrivateKeyJWTBuilder
         protected JWSBuilder $jwsBuilder,
         protected JWK $signatureKey,
         protected string $signatureAlgorithm,
-        protected JWSSerializer $serializer
+        protected JWSSerializer $serializer,
+        protected int $tokenLifetimeInSeconds,
     ) {
     }
 
@@ -34,7 +35,7 @@ class PrivateKeyJWTBuilder
             'sub' => $this->clientId,
             'aud' => $audience,
             'jti' => $jti,
-            'exp' => $now + 300,
+            'exp' => $now + $this->tokenLifetimeInSeconds,
             'iat' => $now,
         ], JSON_THROW_ON_ERROR);
     }

--- a/src/Services/JWS/PrivateKeyJWTBuilder.php
+++ b/src/Services/JWS/PrivateKeyJWTBuilder.php
@@ -26,13 +26,16 @@ class PrivateKeyJWTBuilder
 
     protected function getPayload(string $audience): string
     {
+        $jti = hash('sha256', bin2hex(random_bytes(64)));
+        $now = time();
+
         return json_encode([
-            'iat' => time(),
-            'nbf' => time(),
-            'exp' => time() + 300,
             'iss' => $this->clientId,
             'sub' => $this->clientId,
             'aud' => $audience,
+            'jti' => $jti,
+            'exp' => $now + 300,
+            'iat' => $now,
         ], JSON_THROW_ON_ERROR);
     }
 

--- a/tests/Unit/Services/JWS/PrivateKeyJWTBuilderTest.php
+++ b/tests/Unit/Services/JWS/PrivateKeyJWTBuilderTest.php
@@ -70,12 +70,12 @@ class PrivateKeyJWTBuilderTest extends TestCase
                 $payload = json_decode($jws->getPayload(), true);
 
                 $iat = $payload['iat'];
-                $this->assertSame($iat, $payload['nbf']);
                 $this->assertSame($iat + 300, $payload['exp']);
 
                 $this->assertSame('client_id', $payload['iss']);
                 $this->assertSame('client_id', $payload['sub']);
                 $this->assertSame('audience', $payload['aud']);
+                $this->assertNotEmpty($payload['jti']);
 
                 return true;
             });

--- a/tests/Unit/Services/JWS/PrivateKeyJWTBuilderTest.php
+++ b/tests/Unit/Services/JWS/PrivateKeyJWTBuilderTest.php
@@ -32,6 +32,7 @@ class PrivateKeyJWTBuilderTest extends TestCase
     protected $privateKeyResource;
     protected string $publicKey;
     protected AlgorithmManager $algorithmManager;
+    protected int $tokenLifetimeInSeconds = 60;
 
     protected function setUp(): void
     {
@@ -70,7 +71,7 @@ class PrivateKeyJWTBuilderTest extends TestCase
                 $payload = json_decode($jws->getPayload(), true);
 
                 $iat = $payload['iat'];
-                $this->assertSame($iat + 300, $payload['exp']);
+                $this->assertSame($iat + $this->tokenLifetimeInSeconds, $payload['exp']);
 
                 $this->assertSame('client_id', $payload['iss']);
                 $this->assertSame('client_id', $payload['sub']);
@@ -86,6 +87,7 @@ class PrivateKeyJWTBuilderTest extends TestCase
             getJwkFromResource($this->privateKeyResource),
             'RS256',
             $mockSerializer,
+            $this->tokenLifetimeInSeconds,
         );
 
         $builder->__invoke('audience');
@@ -120,6 +122,7 @@ class PrivateKeyJWTBuilderTest extends TestCase
             getJwkFromResource($this->privateKeyResource),
             'RS256',
             new CompactSerializer(),
+            $this->tokenLifetimeInSeconds,
         );
 
         return $builder->__invoke($audience);

--- a/tests/Unit/Services/JWS/PrivateKeyJWTBuilderTest.php
+++ b/tests/Unit/Services/JWS/PrivateKeyJWTBuilderTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MinVWS\OpenIDConnectLaravel\Tests\Unit\Services\JWS;
+
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\Signature\Algorithm\RS256;
+use Jose\Component\Signature\JWS;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\JWSVerifier;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
+use Jose\Component\Signature\Serializer\Serializer;
+use MinVWS\OpenIDConnectLaravel\Services\JWS\PrivateKeyJWTBuilder;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenSSLAsymmetricKey;
+use PHPUnit\Framework\TestCase;
+
+use function MinVWS\OpenIDConnectLaravel\Tests\{
+    generateOpenSSLKey,
+    getJwkFromResource,
+};
+
+class PrivateKeyJWTBuilderTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected OpenSSLAsymmetricKey $privateKey;
+    protected $privateKeyResource;
+    protected string $publicKey;
+    protected AlgorithmManager $algorithmManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        [$privateKey, $privateKeyResource] = generateOpenSSLKey();
+
+        $this->privateKey = $privateKey;
+        $this->privateKeyResource = $privateKeyResource;
+        $this->publicKey = openssl_pkey_get_details($this->privateKey)['key'];
+
+        $this->algorithmManager = new AlgorithmManager([
+            new RS256(),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->privateKeyResource)) {
+            fclose($this->privateKeyResource);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testPayload(): void
+    {
+        $mockSerializer = Mockery::mock(Serializer::class);
+        $mockSerializer
+            ->shouldReceive('serialize')
+            ->withArgs(function ($jws, $index) {
+                /** @var JWS $jws */
+                $this->assertInstanceOf(JWS::class, $jws);
+                $this->assertSame(0, $index);
+
+                $payload = json_decode($jws->getPayload(), true);
+
+                $iat = $payload['iat'];
+                $this->assertSame($iat, $payload['nbf']);
+                $this->assertSame($iat + 300, $payload['exp']);
+
+                $this->assertSame('client_id', $payload['iss']);
+                $this->assertSame('client_id', $payload['sub']);
+                $this->assertSame('audience', $payload['aud']);
+
+                return true;
+            });
+
+        $builder = new PrivateKeyJWTBuilder(
+            'client_id',
+            new JWSBuilder($this->algorithmManager),
+            getJwkFromResource($this->privateKeyResource),
+            'RS256',
+            $mockSerializer,
+        );
+
+        $builder->__invoke('audience');
+    }
+
+    public function testSignature(): void
+    {
+        // Build JWS
+        $buildJws = $this->generateJws('client_id', 'audience');
+
+        // Unserialize the JWS string to JWS
+        $serializerManager = new JWSSerializerManager([
+            new CompactSerializer(),
+        ]);
+        $jws = $serializerManager->unserialize($buildJws);
+
+        // Create the public JWK from the public key
+        $publicJwk = JWKFactory::createFromKey($this->publicKey);
+
+        // Verify the JWS with the public key
+        $jwsVerifier = new JWSVerifier($this->algorithmManager);
+        $isVerified = $jwsVerifier->verifyWithKey($jws, $publicJwk, 0);
+
+        $this->assertTrue($isVerified);
+    }
+
+    protected function generateJws(string $clientId, string $audience): string
+    {
+        $builder = new PrivateKeyJWTBuilder(
+            $clientId,
+            new JWSBuilder($this->algorithmManager),
+            getJwkFromResource($this->privateKeyResource),
+            'RS256',
+            new CompactSerializer(),
+        );
+
+        return $builder->__invoke($audience);
+    }
+}


### PR DESCRIPTION
Fixes #38 

According to spec https://openid.net/specs/openid-connect-core-1_0-errata2.html#ClientAuthentication.

For the JTI claim I used the same implementation as the OpenID Connect PHP package. 
https://github.com/jumbojett/OpenID-Connect-PHP/blob/1a468a40175e6d3366328678309623985ca2b150/src/OpenIDConnectClient.php#L1929