### PR TITLE
fix: remove overloaded properties of OpenIDConnectClient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "jumbojett/openid-connect-php": "^1.0.0",
+        "jumbojett/openid-connect-php": "^1.0.2",
         "guzzlehttp/guzzle": "^7.5",
         "web-token/jwt-library": "^3.4"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,5 @@ parameters:
     paths:
         - src
     level: 8
-    excludePaths:
-        - src/BaseOpenIDConnectClient.php
 includes:
     - phar://phpstan.phar/conf/bleedingEdge.neon

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -20,15 +20,6 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
 {
     protected ?JweDecryptInterface $jweDecrypter;
     protected ?OpenIDConfiguration $openIDConfiguration;
-    /**
-     * @var int|null Response code from the server
-     */
-    protected ?int $responseCode;
-
-    /**
-     * @var string|null Content type from the server
-     */
-    private ?string $responseContentType;
 
     public function __construct(
         ?string $providerUrl = null,

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -21,6 +21,11 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
     protected ?JweDecryptInterface $jweDecrypter;
     protected ?OpenIDConfiguration $openIDConfiguration;
 
+    /**
+     * @var string|null Content type from the server
+     */
+    private ?string $internalResponseContentType = null;
+
     public function __construct(
         ?string $providerUrl = null,
         ?string $clientId = null,
@@ -190,7 +195,7 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
         }
 
         $this->responseCode = $request->status();
-        $this->responseContentType = $request->header('Content-Type');
+        $this->internalResponseContentType = $request->header('Content-Type');
 
         if ($request->failed()) {
             throw new OpenIDConnectClientException(
@@ -218,7 +223,7 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
      */
     public function getResponseContentType(): ?string
     {
-        return $this->responseContentType;
+        return $this->internalResponseContentType;
     }
 
     public function setTlsVerify(bool|string $tlsVerify): void

--- a/src/Services/ExceptionHandler.php
+++ b/src/Services/ExceptionHandler.php
@@ -103,6 +103,8 @@ class ExceptionHandler implements ExceptionHandlerInterface
 
     protected function getRequest(): ?Request
     {
-        return request();
+        /** @psalm-var Request $request */
+        $request = request();
+        return $request;
     }
 }

--- a/src/Services/ExceptionHandler.php
+++ b/src/Services/ExceptionHandler.php
@@ -103,11 +103,6 @@ class ExceptionHandler implements ExceptionHandlerInterface
 
     protected function getRequest(): ?Request
     {
-        $request = request();
-        if (!($request instanceof Request)) {
-            return null;
-        }
-
-        return $request;
+        return request();
     }
 }

--- a/tests/Feature/Http/Controllers/LoginControllerResponseTest.php
+++ b/tests/Feature/Http/Controllers/LoginControllerResponseTest.php
@@ -78,7 +78,7 @@ class LoginControllerResponseTest extends TestCase
 
         $response
             ->assertStatus(302)
-            ->assertRedirectContains("https://provider.rdobeheer.nl/authorize")
+            ->assertRedirectContains("https://provider.example.com/authorize")
             ->assertRedirectContains('response_type=code')
             ->assertRedirectContains('redirect_uri=http%3A%2F%2Flocalhost%2Foidc%2Flogin')
             ->assertRedirectContains('client_id=test-client-id')
@@ -108,7 +108,7 @@ class LoginControllerResponseTest extends TestCase
 
         $response
             ->assertStatus(302)
-            ->assertRedirectContains("https://provider.rdobeheer.nl/authorize");
+            ->assertRedirectContains("https://provider.example.com/authorize");
 
         if ($codeChallengeShouldBeSet) {
             $response
@@ -137,7 +137,7 @@ class LoginControllerResponseTest extends TestCase
             // Token requested by OpenIDConnectClient::authenticate() function.
             // Currently needed because the package requests the token endpoint before checking the state.
             // TODO: Remove if https://github.com/jumbojett/OpenID-Connect-PHP/pull/447 is merged.
-            'https://provider.rdobeheer.nl/token' => Http::response([
+            'https://provider.example.com/token' => Http::response([
                 'access_token' => 'access-token-from-token-endpoint',
                 'id_token' => 'some-valid-token-not-needed-for-this-state-check',
                 'token_type' => 'Bearer',
@@ -147,7 +147,7 @@ class LoginControllerResponseTest extends TestCase
 
         // Set OIDC config
         $this->mockOpenIDConfigurationLoader();
-        Config::set('oidc.issuer', 'https://provider.rdobeheer.nl');
+        Config::set('oidc.issuer', 'https://provider.example.com');
         Config::set('oidc.client_id', 'test-client-id');
         Config::set('oidc.client_secret', 'the-secret-client-secret');
 
@@ -172,29 +172,29 @@ class LoginControllerResponseTest extends TestCase
     public function testIdTokenSignedWithClientSecret(): void
     {
         $idToken = generateJwt([
-            "iss" => "https://provider.rdobeheer.nl",
+            "iss" => "https://provider.example.com",
             "aud" => 'test-client-id',
             "sub" => 'test-subject',
         ], 'the-secret-client-secret');
 
         Http::fake([
             // Token requested by OpenIDConnectClient::authenticate() function.
-            'https://provider.rdobeheer.nl/token' => Http::response([
+            'https://provider.example.com/token' => Http::response([
                 'access_token' => 'access-token-from-token-endpoint',
                 'id_token' => $idToken,
                 'token_type' => 'Bearer',
                 'expires_in' => 3600,
             ]),
             // User info requested by OpenIDConnectClient::requestUserInfo() function.
-            'https://provider.rdobeheer.nl/userinfo?schema=openid' => Http::response([
-                'email' => 'tester@rdobeheer.nl',
+            'https://provider.example.com/userinfo?schema=openid' => Http::response([
+                'email' => 'tester@example.com',
             ]),
         ]);
 
         // Set OIDC config
         $this->mockOpenIDConfigurationLoader();
 
-        Config::set('oidc.issuer', 'https://provider.rdobeheer.nl');
+        Config::set('oidc.issuer', 'https://provider.example.com');
         Config::set('oidc.client_id', 'test-client-id');
         Config::set('oidc.client_secret', 'the-secret-client-secret');
 
@@ -207,7 +207,7 @@ class LoginControllerResponseTest extends TestCase
         $response->assertStatus(200);
         $response->assertJson([
             'userInfo' => [
-                'email' => 'tester@rdobeheer.nl',
+                'email' => 'tester@example.com',
             ]
         ]);
 
@@ -216,11 +216,11 @@ class LoginControllerResponseTest extends TestCase
 
         Http::assertSentCount(2);
         Http::assertSentInOrder([
-            'https://provider.rdobeheer.nl/token',
-            'https://provider.rdobeheer.nl/userinfo?schema=openid',
+            'https://provider.example.com/token',
+            'https://provider.example.com/userinfo?schema=openid',
         ]);
         Http::assertSent(function (Request $request) {
-            if ($request->url() === 'https://provider.rdobeheer.nl/token') {
+            if ($request->url() === 'https://provider.example.com/token') {
                 $this->assertSame(
                     expected: 'POST',
                     actual: $request->method(),
@@ -236,7 +236,7 @@ class LoginControllerResponseTest extends TestCase
                 return true;
             }
 
-            if ($request->url() === 'https://provider.rdobeheer.nl/userinfo?schema=openid') {
+            if ($request->url() === 'https://provider.example.com/userinfo?schema=openid') {
                 $this->assertSame(
                     expected: 'GET',
                     actual: $request->method(),
@@ -256,14 +256,14 @@ class LoginControllerResponseTest extends TestCase
     public function testIdTokenSignedWithIncorrectClientSecret(): void
     {
         $idToken = generateJwt([
-            "iss" => "https://provider.rdobeheer.nl",
+            "iss" => "https://provider.example.com",
             "aud" => 'test-client-id',
             "sub" => 'test-subject',
         ], 'not-the-secret-client-secret');
 
         Http::fake([
             // Token requested by OpenIDConnectClient::authenticate() function.
-            'https://provider.rdobeheer.nl/token' => Http::response([
+            'https://provider.example.com/token' => Http::response([
                 'access_token' => 'access-token-from-token-endpoint',
                 'id_token' => $idToken,
                 'token_type' => 'Bearer',
@@ -273,7 +273,7 @@ class LoginControllerResponseTest extends TestCase
 
         // Set OIDC config
         $this->mockOpenIDConfigurationLoader();
-        Config::set('oidc.issuer', 'https://provider.rdobeheer.nl');
+        Config::set('oidc.issuer', 'https://provider.example.com');
         Config::set('oidc.client_id', 'test-client-id');
         Config::set('oidc.client_secret', 'the-secret-client-secret');
 
@@ -296,10 +296,10 @@ class LoginControllerResponseTest extends TestCase
 
         Http::assertSentCount(1);
         Http::assertSentInOrder([
-            'https://provider.rdobeheer.nl/token',
+            'https://provider.example.com/token',
         ]);
         Http::assertSent(function (Request $request) {
-            if ($request->url() === 'https://provider.rdobeheer.nl/token') {
+            if ($request->url() === 'https://provider.example.com/token') {
                 $this->assertSame(
                     expected: 'POST',
                     actual: $request->method(),
@@ -321,28 +321,28 @@ class LoginControllerResponseTest extends TestCase
     public function testIdTokenAndUserinfoSignedWithClientSecret(): void
     {
         $idToken = generateJwt([
-            "iss" => "https://provider.rdobeheer.nl",
+            "iss" => "https://provider.example.com",
             "aud" => 'test-client-id',
             "sub" => 'test-subject',
         ], 'the-secret-client-secret');
 
         $signedUserInfo = generateJwt([
-            "iss" => "https://provider.rdobeheer.nl",
+            "iss" => "https://provider.example.com",
             "aud" => 'test-client-id',
             "sub" => 'test-subject',
-            "email" => 'tester@rdobeheer.nl',
+            "email" => 'tester@example.com',
         ], 'the-secret-client-secret');
 
         Http::fake([
             // Token requested by OpenIDConnectClient::authenticate() function.
-            'https://provider.rdobeheer.nl/token' => Http::response([
+            'https://provider.example.com/token' => Http::response([
                 'access_token' => 'access-token-from-token-endpoint',
                 'id_token' => $idToken,
                 'token_type' => 'Bearer',
                 'expires_in' => 3600,
             ]),
             // User info requested by OpenIDConnectClient::requestUserInfo() function.
-            'https://provider.rdobeheer.nl/userinfo?schema=openid' => Http::response(
+            'https://provider.example.com/userinfo?schema=openid' => Http::response(
                 body: $signedUserInfo,
                 status: 200,
                 headers: [
@@ -354,7 +354,7 @@ class LoginControllerResponseTest extends TestCase
         // Set OIDC config
         $this->mockOpenIDConfigurationLoader();
 
-        Config::set('oidc.issuer', 'https://provider.rdobeheer.nl');
+        Config::set('oidc.issuer', 'https://provider.example.com');
         Config::set('oidc.client_id', 'test-client-id');
         Config::set('oidc.client_secret', 'the-secret-client-secret');
 
@@ -367,7 +367,7 @@ class LoginControllerResponseTest extends TestCase
         $response->assertStatus(200);
         $response->assertJson([
             'userInfo' => [
-                'email' => 'tester@rdobeheer.nl',
+                'email' => 'tester@example.com',
             ]
         ]);
 
@@ -376,11 +376,11 @@ class LoginControllerResponseTest extends TestCase
 
         Http::assertSentCount(2);
         Http::assertSentInOrder([
-            'https://provider.rdobeheer.nl/token',
-            'https://provider.rdobeheer.nl/userinfo?schema=openid',
+            'https://provider.example.com/token',
+            'https://provider.example.com/userinfo?schema=openid',
         ]);
         Http::assertSent(function (Request $request) {
-            if ($request->url() === 'https://provider.rdobeheer.nl/token') {
+            if ($request->url() === 'https://provider.example.com/token') {
                 $this->assertSame(
                     expected: 'POST',
                     actual: $request->method(),
@@ -396,7 +396,7 @@ class LoginControllerResponseTest extends TestCase
                 return true;
             }
 
-            if ($request->url() === 'https://provider.rdobeheer.nl/userinfo?schema=openid') {
+            if ($request->url() === 'https://provider.example.com/userinfo?schema=openid') {
                 $this->assertSame(
                     expected: 'GET',
                     actual: $request->method(),
@@ -416,28 +416,28 @@ class LoginControllerResponseTest extends TestCase
     public function testSubClaimIdTokenDoesNotEqualsSubClaimUserinfo(): void
     {
         $idToken = generateJwt([
-            "iss" => "https://provider.rdobeheer.nl",
+            "iss" => "https://provider.example.com",
             "aud" => 'test-client-id',
             "sub" => 'test-subject',
         ], 'the-secret-client-secret');
 
         $signedUserInfo = generateJwt([
-            "iss" => "https://provider.rdobeheer.nl",
+            "iss" => "https://provider.example.com",
             "aud" => 'test-client-id',
             "sub" => 'different-subject',
-            "email" => 'tester@rdobeheer.nl',
+            "email" => 'tester@example.com',
         ], 'the-secret-client-secret');
 
         Http::fake([
             // Token requested by OpenIDConnectClient::authenticate() function.
-            'https://provider.rdobeheer.nl/token' => Http::response([
+            'https://provider.example.com/token' => Http::response([
                 'access_token' => 'access-token-from-token-endpoint',
                 'id_token' => $idToken,
                 'token_type' => 'Bearer',
                 'expires_in' => 3600,
             ]),
             // User info requested by OpenIDConnectClient::requestUserInfo() function.
-            'https://provider.rdobeheer.nl/userinfo?schema=openid' => Http::response(
+            'https://provider.example.com/userinfo?schema=openid' => Http::response(
                 body: $signedUserInfo,
                 status: 200,
                 headers: [
@@ -449,7 +449,7 @@ class LoginControllerResponseTest extends TestCase
         // Set OIDC config
         $this->mockOpenIDConfigurationLoader();
 
-        Config::set('oidc.issuer', 'https://provider.rdobeheer.nl');
+        Config::set('oidc.issuer', 'https://provider.example.com');
         Config::set('oidc.client_id', 'test-client-id');
         Config::set('oidc.client_secret', 'the-secret-client-secret');
 
@@ -475,11 +475,11 @@ class LoginControllerResponseTest extends TestCase
 
         Http::assertSentCount(2);
         Http::assertSentInOrder([
-            'https://provider.rdobeheer.nl/token',
-            'https://provider.rdobeheer.nl/userinfo?schema=openid',
+            'https://provider.example.com/token',
+            'https://provider.example.com/userinfo?schema=openid',
         ]);
         Http::assertSent(function (Request $request) {
-            if ($request->url() === 'https://provider.rdobeheer.nl/token') {
+            if ($request->url() === 'https://provider.example.com/token') {
                 $this->assertSame(
                     expected: 'POST',
                     actual: $request->method(),
@@ -495,7 +495,7 @@ class LoginControllerResponseTest extends TestCase
                 return true;
             }
 
-            if ($request->url() === 'https://provider.rdobeheer.nl/userinfo?schema=openid') {
+            if ($request->url() === 'https://provider.example.com/userinfo?schema=openid') {
                 $this->assertSame(
                     expected: 'GET',
                     actual: $request->method(),
@@ -516,7 +516,7 @@ class LoginControllerResponseTest extends TestCase
     {
         Http::fake([
             // Token requested by OpenIDConnectClient::authenticate() function.
-            'https://provider.rdobeheer.nl/token' => Http::response([
+            'https://provider.example.com/token' => Http::response([
                 'access_token' => 'access-token-from-token-endpoint',
                 'id_token' => 'does-not-matter-not-testing-id-token',
                 'token_type' => 'Bearer',
@@ -527,7 +527,7 @@ class LoginControllerResponseTest extends TestCase
         // Set OIDC provider configuration
         $this->mockOpenIDConfigurationLoader(tokenEndpointAuthMethodsSupported: ['private_key_jwt']);
 
-        Config::set('oidc.issuer', 'https://provider.rdobeheer.nl');
+        Config::set('oidc.issuer', 'https://provider.example.com');
         Config::set('oidc.client_id', 'test-client-id');
 
         // Set client private key
@@ -547,14 +547,14 @@ class LoginControllerResponseTest extends TestCase
 
         Http::assertSentCount(1);
         Http::assertSentInOrder([
-            'https://provider.rdobeheer.nl/token',
+            'https://provider.example.com/token',
         ]);
         Http::assertSent(function (Request $request) {
-            if (!in_array($request->url(), ['https://provider.rdobeheer.nl/token'], true)) {
+            if (!in_array($request->url(), ['https://provider.example.com/token'], true)) {
                 return false;
             }
 
-            if ($request->url() === 'https://provider.rdobeheer.nl/token') {
+            if ($request->url() === 'https://provider.example.com/token') {
                 $this->assertSame(
                     expected: 'POST',
                     actual: $request->method(),
@@ -610,16 +610,16 @@ class LoginControllerResponseTest extends TestCase
             frontchannelLogoutSessionSupported: false,
             backchannelLogoutSupported: false,
             backchannelLogoutSessionSupported: false,
-            issuer: "https://provider.rdobeheer.nl",
-            authorizationEndpoint: "https://provider.rdobeheer.nl/authorize",
-            jwksUri: "https://provider.rdobeheer.nl/jwks",
-            tokenEndpoint: "https://provider.rdobeheer.nl/token",
+            issuer: "https://provider.example.com",
+            authorizationEndpoint: "https://provider.example.com/authorize",
+            jwksUri: "https://provider.example.com/jwks",
+            tokenEndpoint: "https://provider.example.com/token",
             scopesSupported: ["openid"],
             responseTypesSupported: ["code"],
             responseModesSupported: ["query"],
             subjectTypesSupported: ["pairwise"],
             idTokenSigningAlgValuesSupported: ["RS256"],
-            userinfoEndpoint: "https://provider.rdobeheer.nl/userinfo",
+            userinfoEndpoint: "https://provider.example.com/userinfo",
             codeChallengeMethodsSupported: $codeChallengeMethodsSupported,
         );
     }

--- a/tests/Feature/Http/Controllers/LoginControllerResponseTest.php
+++ b/tests/Feature/Http/Controllers/LoginControllerResponseTest.php
@@ -152,14 +152,14 @@ class LoginControllerResponseTest extends TestCase
         Config::set('oidc.client_secret', 'the-secret-client-secret');
 
         // Mock LoginResponseHandlerInterface to check handleExceptionWhileAuthenticate is called.
-        $mock = Mockery::mock(ExceptionHandlerInterface::class);
-        $mock
+        $mockExceptionHandler = Mockery::mock(ExceptionHandlerInterface::class);
+        $mockExceptionHandler
             ->shouldReceive('handleExceptionWhileAuthenticate')
             ->withArgs(function (OpenIDConnectClientException $e) {
                 return $e->getMessage() === 'Unable to determine state';
             })
             ->once();
-        $this->app->instance(ExceptionHandlerInterface::class, $mock);
+        $this->app->instance(ExceptionHandlerInterface::class, $mockExceptionHandler);
 
         // Set the current state, which is usually generated and saved in the session before login,
         // and sent to the issuer during the login redirect.
@@ -278,14 +278,14 @@ class LoginControllerResponseTest extends TestCase
         Config::set('oidc.client_secret', 'the-secret-client-secret');
 
         // Mock LoginResponseHandlerInterface to check handleExceptionWhileAuthenticate is called.
-        $mock = Mockery::mock(ExceptionHandlerInterface::class);
-        $mock
+        $mockExceptionHandler = Mockery::mock(ExceptionHandlerInterface::class);
+        $mockExceptionHandler
             ->shouldReceive('handleExceptionWhileAuthenticate')
             ->withArgs(function (OpenIDConnectClientException $e) {
                 return $e->getMessage() === 'Unable to verify signature';
             })
             ->once();
-        $this->app->instance(ExceptionHandlerInterface::class, $mock);
+        $this->app->instance(ExceptionHandlerInterface::class, $mockExceptionHandler);
 
         // Set the current state, which is usually generated and saved in the session before login,
         // and sent to the issuer during the login redirect.
@@ -370,6 +370,105 @@ class LoginControllerResponseTest extends TestCase
                 'email' => 'tester@rdobeheer.nl',
             ]
         ]);
+
+        $this->assertEmpty(session('openid_connect_state'));
+        $this->assertEmpty(session('openid_connect_nonce'));
+
+        Http::assertSentCount(2);
+        Http::assertSentInOrder([
+            'https://provider.rdobeheer.nl/token',
+            'https://provider.rdobeheer.nl/userinfo?schema=openid',
+        ]);
+        Http::assertSent(function (Request $request) {
+            if ($request->url() === 'https://provider.rdobeheer.nl/token') {
+                $this->assertSame(
+                    expected: 'POST',
+                    actual: $request->method(),
+                );
+                $this->assertSame(
+                    expected: 'grant_type=authorization_code'
+                    . '&code=some-code'
+                    . '&redirect_uri=http%3A%2F%2Flocalhost%2Foidc%2Flogin'
+                    . '&client_id=test-client-id'
+                    . '&client_secret=the-secret-client-secret',
+                    actual: $request->body(),
+                );
+                return true;
+            }
+
+            if ($request->url() === 'https://provider.rdobeheer.nl/userinfo?schema=openid') {
+                $this->assertSame(
+                    expected: 'GET',
+                    actual: $request->method(),
+                );
+                $this->assertSame(
+                    expected: [
+                        'Bearer access-token-from-token-endpoint'
+                    ],
+                    actual: $request->header('Authorization'),
+                );
+            }
+
+            return true;
+        });
+    }
+
+    public function testSubClaimIdTokenDoesNotEqualsSubClaimUserinfo(): void
+    {
+        $idToken = generateJwt([
+            "iss" => "https://provider.rdobeheer.nl",
+            "aud" => 'test-client-id',
+            "sub" => 'test-subject',
+        ], 'the-secret-client-secret');
+
+        $signedUserInfo = generateJwt([
+            "iss" => "https://provider.rdobeheer.nl",
+            "aud" => 'test-client-id',
+            "sub" => 'different-subject',
+            "email" => 'tester@rdobeheer.nl',
+        ], 'the-secret-client-secret');
+
+        Http::fake([
+            // Token requested by OpenIDConnectClient::authenticate() function.
+            'https://provider.rdobeheer.nl/token' => Http::response([
+                'access_token' => 'access-token-from-token-endpoint',
+                'id_token' => $idToken,
+                'token_type' => 'Bearer',
+                'expires_in' => 3600,
+            ]),
+            // User info requested by OpenIDConnectClient::requestUserInfo() function.
+            'https://provider.rdobeheer.nl/userinfo?schema=openid' => Http::response(
+                body: $signedUserInfo,
+                status: 200,
+                headers: [
+                    'Content-Type' => 'application/jwt',
+                ]
+            ),
+        ]);
+
+        // Set OIDC config
+        $this->mockOpenIDConfigurationLoader();
+
+        Config::set('oidc.issuer', 'https://provider.rdobeheer.nl');
+        Config::set('oidc.client_id', 'test-client-id');
+        Config::set('oidc.client_secret', 'the-secret-client-secret');
+
+        // Mock LoginResponseHandlerInterface to check handleExceptionWhileRequestUserInfo is called.
+        $mockExceptionHandler = Mockery::mock(ExceptionHandlerInterface::class);
+        $mockExceptionHandler
+            ->shouldReceive('handleExceptionWhileRequestUserInfo')
+            ->withArgs(function (OpenIDConnectClientException $e) {
+                return $e->getMessage() === 'Invalid JWT signature';
+            })
+            ->once();
+        $this->app->instance(ExceptionHandlerInterface::class, $mockExceptionHandler);
+
+        // Set the current state, which is usually generated and saved in the session before login,
+        // and sent to the issuer during the login redirect.
+        Session::put('openid_connect_state', 'some-state');
+
+        // We simulate here that the user now comes back after successful login at issuer.
+        $this->getRoute('oidc.login', ['code' => 'some-code', 'state' => 'some-state']);
 
         $this->assertEmpty(session('openid_connect_state'));
         $this->assertEmpty(session('openid_connect_nonce'));

--- a/tests/Feature/Http/Controllers/LoginControllerResponseTest.php
+++ b/tests/Feature/Http/Controllers/LoginControllerResponseTest.php
@@ -253,6 +253,72 @@ class LoginControllerResponseTest extends TestCase
         });
     }
 
+    public function testIdTokenSignedWithIncorrectClientSecret(): void
+    {
+        $idToken = generateJwt([
+            "iss" => "https://provider.rdobeheer.nl",
+            "aud" => 'test-client-id',
+            "sub" => 'test-subject',
+        ], 'not-the-secret-client-secret');
+
+        Http::fake([
+            // Token requested by OpenIDConnectClient::authenticate() function.
+            'https://provider.rdobeheer.nl/token' => Http::response([
+                'access_token' => 'access-token-from-token-endpoint',
+                'id_token' => $idToken,
+                'token_type' => 'Bearer',
+                'expires_in' => 3600,
+            ]),
+        ]);
+
+        // Set OIDC config
+        $this->mockOpenIDConfigurationLoader();
+        Config::set('oidc.issuer', 'https://provider.rdobeheer.nl');
+        Config::set('oidc.client_id', 'test-client-id');
+        Config::set('oidc.client_secret', 'the-secret-client-secret');
+
+        // Mock LoginResponseHandlerInterface to check handleExceptionWhileAuthenticate is called.
+        $mock = Mockery::mock(ExceptionHandlerInterface::class);
+        $mock
+            ->shouldReceive('handleExceptionWhileAuthenticate')
+            ->withArgs(function (OpenIDConnectClientException $e) {
+                return $e->getMessage() === 'Unable to verify signature';
+            })
+            ->once();
+        $this->app->instance(ExceptionHandlerInterface::class, $mock);
+
+        // Set the current state, which is usually generated and saved in the session before login,
+        // and sent to the issuer during the login redirect.
+        Session::put('openid_connect_state', 'some-state');
+
+        // We simulate here that the user now comes back after successful login at issuer.
+        $this->getRoute('oidc.login', ['code' => 'some-code', 'state' => 'some-state']);
+
+        Http::assertSentCount(1);
+        Http::assertSentInOrder([
+            'https://provider.rdobeheer.nl/token',
+        ]);
+        Http::assertSent(function (Request $request) {
+            if ($request->url() === 'https://provider.rdobeheer.nl/token') {
+                $this->assertSame(
+                    expected: 'POST',
+                    actual: $request->method(),
+                );
+                $this->assertSame(
+                    expected: 'grant_type=authorization_code'
+                    . '&code=some-code'
+                    . '&redirect_uri=http%3A%2F%2Flocalhost%2Foidc%2Flogin'
+                    . '&client_id=test-client-id'
+                    . '&client_secret=the-secret-client-secret',
+                    actual: $request->body(),
+                );
+                return true;
+            }
+            return true;
+        });
+    }
+
+
     public function testTokenSignedWithPrivateKey(): void
     {
         Http::fake([

--- a/tests/Feature/Http/Controllers/LoginControllerResponseTest.php
+++ b/tests/Feature/Http/Controllers/LoginControllerResponseTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MinVWS\OpenIDConnectLaravel\Tests\Feature\Http\Controllers;
 
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Session;
@@ -159,8 +158,7 @@ class LoginControllerResponseTest extends TestCase
             ->withArgs(function (OpenIDConnectClientException $e) {
                 return $e->getMessage() === 'Unable to determine state';
             })
-            ->once()
-            ->andReturn(new Response('', 400));
+            ->once();
         $this->app->instance(ExceptionHandlerInterface::class, $mock);
 
         // Set the current state, which is usually generated and saved in the session before login,
@@ -168,9 +166,7 @@ class LoginControllerResponseTest extends TestCase
         Session::put('openid_connect_state', 'some-state');
 
         // We simulate here that the state does not match with the state in the session.
-        // And that the repsonse of ExceptionHandlerInterface is returned.
-        $response = $this->getRoute('oidc.login', ['code' => 'some-code', 'state' => 'a-different-state']);
-        $response->assertStatus(400);
+        $this->getRoute('oidc.login', ['code' => 'some-code', 'state' => 'a-different-state']);
     }
 
     public function testIdTokenSignedWithClientSecret(): void

--- a/tests/Feature/Http/Controllers/LoginControllerTest.php
+++ b/tests/Feature/Http/Controllers/LoginControllerTest.php
@@ -32,7 +32,7 @@ class LoginControllerTest extends TestCase
         $response = $this->get(route('oidc.login'));
         $response
             ->assertStatus(302)
-            ->assertRedirectContains("https://provider.rdobeheer.nl/authorize")
+            ->assertRedirectContains("https://provider.example.com/authorize")
             ->assertRedirectContains('response_type=code')
             ->assertRedirectContains('redirect_uri=http%3A%2F%2Flocalhost%2Foidc%2Flogin')
             ->assertRedirectContains('client_id=test-client-id')
@@ -55,7 +55,7 @@ class LoginControllerTest extends TestCase
         $response = $this->get(route('oidc.login', ['login_hint' => 'test-login-hint']));
         $response
             ->assertStatus(302)
-            ->assertRedirectContains("https://provider.rdobeheer.nl/authorize")
+            ->assertRedirectContains("https://provider.example.com/authorize")
             ->assertRedirectContains('test-client-id')
             ->assertRedirectContains('login_hint=test-login-hint')
             ->assertRedirectContains($scopeInUrl);
@@ -79,7 +79,7 @@ class LoginControllerTest extends TestCase
         $response = $this->get(route('oidc.login', ['login_hint' => 'test-login-hint']));
         $response
             ->assertStatus(302)
-            ->assertRedirectContains("https://provider.rdobeheer.nl/authorize")
+            ->assertRedirectContains("https://provider.example.com/authorize")
             ->assertRedirectContains('test-client-id')
             ->assertRedirectContains('login_hint=test-login-hint');
     }
@@ -139,16 +139,16 @@ class LoginControllerTest extends TestCase
             frontchannelLogoutSessionSupported: false,
             backchannelLogoutSupported: false,
             backchannelLogoutSessionSupported: false,
-            issuer: "https://provider.rdobeheer.nl",
-            authorizationEndpoint: "https://provider.rdobeheer.nl/authorize",
-            jwksUri: "https://provider.rdobeheer.nl/jwks",
-            tokenEndpoint: "https://provider.rdobeheer.nl/token",
+            issuer: "https://provider.example.com",
+            authorizationEndpoint: "https://provider.example.com/authorize",
+            jwksUri: "https://provider.example.com/jwks",
+            tokenEndpoint: "https://provider.example.com/token",
             scopesSupported: ["openid"],
             responseTypesSupported: ["code"],
             responseModesSupported: ["query"],
             subjectTypesSupported: ["pairwise"],
             idTokenSigningAlgValuesSupported: ["RS256"],
-            userinfoEndpoint: "https://provider.rdobeheer.nl/userinfo",
+            userinfoEndpoint: "https://provider.example.com/userinfo",
             codeChallengeMethodsSupported: ["S256"],
         );
     }

--- a/tests/Feature/OpenIDConfiguration/OpenIDConfigurationLoaderTest.php
+++ b/tests/Feature/OpenIDConfiguration/OpenIDConfigurationLoaderTest.php
@@ -27,17 +27,17 @@ class OpenIDConfigurationLoaderTest extends TestCase
         $this->fakeSuccessfulResponse();
 
         $loader = new OpenIDConfigurationLoader(
-            'https://provider.rdobeheer.nl',
+            'https://provider.example.com',
         );
 
         $configuration = $loader->getConfiguration();
 
         $this->assertSame("3.0", $configuration->version);
-        $this->assertSame("https://provider.rdobeheer.nl", $configuration->issuer);
-        $this->assertSame("https://provider.rdobeheer.nl/authorize", $configuration->authorizationEndpoint);
-        $this->assertSame("https://provider.rdobeheer.nl/jwks", $configuration->jwksUri);
-        $this->assertSame("https://provider.rdobeheer.nl/token", $configuration->tokenEndpoint);
-        $this->assertSame("https://provider.rdobeheer.nl/userinfo", $configuration->userinfoEndpoint);
+        $this->assertSame("https://provider.example.com", $configuration->issuer);
+        $this->assertSame("https://provider.example.com/authorize", $configuration->authorizationEndpoint);
+        $this->assertSame("https://provider.example.com/jwks", $configuration->jwksUri);
+        $this->assertSame("https://provider.example.com/token", $configuration->tokenEndpoint);
+        $this->assertSame("https://provider.example.com/userinfo", $configuration->userinfoEndpoint);
     }
 
     public function testConfigurationIsLoadedMultipleTimesWhenNotCached(): void
@@ -45,7 +45,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
         $this->fakeSuccessfulResponse();
 
         $loader = new OpenIDConfigurationLoader(
-            'https://provider.rdobeheer.nl',
+            'https://provider.example.com',
         );
 
         // Load 2 times
@@ -55,11 +55,11 @@ class OpenIDConfigurationLoaderTest extends TestCase
         Http::assertSentCount(2);
 
         $this->assertSame("3.0", $configuration->version);
-        $this->assertSame("https://provider.rdobeheer.nl", $configuration->issuer);
-        $this->assertSame("https://provider.rdobeheer.nl/authorize", $configuration->authorizationEndpoint);
-        $this->assertSame("https://provider.rdobeheer.nl/jwks", $configuration->jwksUri);
-        $this->assertSame("https://provider.rdobeheer.nl/token", $configuration->tokenEndpoint);
-        $this->assertSame("https://provider.rdobeheer.nl/userinfo", $configuration->userinfoEndpoint);
+        $this->assertSame("https://provider.example.com", $configuration->issuer);
+        $this->assertSame("https://provider.example.com/authorize", $configuration->authorizationEndpoint);
+        $this->assertSame("https://provider.example.com/jwks", $configuration->jwksUri);
+        $this->assertSame("https://provider.example.com/token", $configuration->tokenEndpoint);
+        $this->assertSame("https://provider.example.com/userinfo", $configuration->userinfoEndpoint);
     }
 
     public function testConfigurationIsCached(): void
@@ -67,7 +67,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
         $this->fakeSuccessfulResponse();
 
         $loader = new OpenIDConfigurationLoader(
-            issuer: 'https://provider.rdobeheer.nl',
+            issuer: 'https://provider.example.com',
             cacheStore: Cache::store('array'),
             cacheTtl: 86400,
         );
@@ -82,11 +82,11 @@ class OpenIDConfigurationLoaderTest extends TestCase
         Http::assertSentCount(1);
 
         $this->assertSame("3.0", $configuration->version);
-        $this->assertSame("https://provider.rdobeheer.nl", $configuration->issuer);
-        $this->assertSame("https://provider.rdobeheer.nl/authorize", $configuration->authorizationEndpoint);
-        $this->assertSame("https://provider.rdobeheer.nl/jwks", $configuration->jwksUri);
-        $this->assertSame("https://provider.rdobeheer.nl/token", $configuration->tokenEndpoint);
-        $this->assertSame("https://provider.rdobeheer.nl/userinfo", $configuration->userinfoEndpoint);
+        $this->assertSame("https://provider.example.com", $configuration->issuer);
+        $this->assertSame("https://provider.example.com/authorize", $configuration->authorizationEndpoint);
+        $this->assertSame("https://provider.example.com/jwks", $configuration->jwksUri);
+        $this->assertSame("https://provider.example.com/token", $configuration->tokenEndpoint);
+        $this->assertSame("https://provider.example.com/userinfo", $configuration->userinfoEndpoint);
     }
 
     public function testLoaderThrowsExceptionWhenProviderReturns400ResponseCode(): void
@@ -97,7 +97,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
         $this->expectExceptionMessage("Could not load OpenID configuration from issuer");
 
         $loader = new OpenIDConfigurationLoader(
-            'https://provider.rdobeheer.nl',
+            'https://provider.example.com',
         );
 
         $configuration = $loader->getConfiguration();
@@ -110,14 +110,14 @@ class OpenIDConfigurationLoaderTest extends TestCase
 
         try {
             $loader = new OpenIDConfigurationLoader(
-                'https://provider.rdobeheer.nl',
+                'https://provider.example.com',
             );
             $configuration = $loader->getConfiguration();
         } catch (OpenIDConfigurationLoaderException $exception) {
             $this->assertSame("Could not load OpenID configuration from issuer", $exception->getMessage());
 
             $context = $exception->context();
-            $this->assertSame("https://provider.rdobeheer.nl", $context['issuer']);
+            $this->assertSame("https://provider.example.com", $context['issuer']);
             $this->assertSame("/.well-known/openid-configuration", $context['url']);
             $this->assertSame(400, $context['response_status_code']);
         }
@@ -129,14 +129,14 @@ class OpenIDConfigurationLoaderTest extends TestCase
 
         try {
             $loader = new OpenIDConfigurationLoader(
-                'https://provider.rdobeheer.nl',
+                'https://provider.example.com',
             );
             $configuration = $loader->getConfiguration();
         } catch (OpenIDConfigurationLoaderException $exception) {
             $this->assertSame("Could not load OpenID configuration from issuer", $exception->getMessage());
 
             $context = $exception->context();
-            $this->assertSame("https://provider.rdobeheer.nl", $context['issuer']);
+            $this->assertSame("https://provider.example.com", $context['issuer']);
             $this->assertSame("/.well-known/openid-configuration", $context['url']);
             $this->assertSame(500, $context['response_status_code']);
         }
@@ -148,14 +148,14 @@ class OpenIDConfigurationLoaderTest extends TestCase
 
         try {
             $loader = new OpenIDConfigurationLoader(
-                'https://provider.rdobeheer.nl',
+                'https://provider.example.com',
             );
             $configuration = $loader->getConfiguration();
         } catch (OpenIDConfigurationLoaderException $exception) {
             $this->assertSame("Response body of OpenID configuration is not JSON", $exception->getMessage());
 
             $context = $exception->context();
-            $this->assertSame("https://provider.rdobeheer.nl", $context['issuer']);
+            $this->assertSame("https://provider.example.com", $context['issuer']);
             $this->assertSame("/.well-known/openid-configuration", $context['url']);
             $this->assertSame(200, $context['response_status_code']);
             $this->assertSame('', $context['response_body']);
@@ -168,14 +168,14 @@ class OpenIDConfigurationLoaderTest extends TestCase
 
         try {
             $loader = new OpenIDConfigurationLoader(
-                'https://provider.rdobeheer.nl',
+                'https://provider.example.com',
             );
             $configuration = $loader->getConfiguration();
         } catch (OpenIDConfigurationLoaderException $exception) {
             $this->assertSame("Response body of OpenID configuration is not JSON", $exception->getMessage());
 
             $context = $exception->context();
-            $this->assertSame("https://provider.rdobeheer.nl", $context['issuer']);
+            $this->assertSame("https://provider.example.com", $context['issuer']);
             $this->assertSame("/.well-known/openid-configuration", $context['url']);
             $this->assertSame(200, $context['response_status_code']);
             $this->assertSame('some invalid response', $context['response_body']);
@@ -189,7 +189,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
 
 
         $loader = new OpenIDConfigurationLoader(
-            'https://provider.rdobeheer.nl',
+            'https://provider.example.com',
         );
         $configuration = $loader->getConfiguration();
 
@@ -205,7 +205,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
         $this->fakeSuccessfulResponse();
 
         $loader = new OpenIDConfigurationLoader(
-            issuer: 'https://provider.rdobeheer.nl',
+            issuer: 'https://provider.example.com',
             cacheStore: Cache::store('null'),
         );
 
@@ -216,17 +216,17 @@ class OpenIDConfigurationLoaderTest extends TestCase
         Http::assertSentCount(2);
 
         $this->assertSame("3.0", $configuration->version);
-        $this->assertSame("https://provider.rdobeheer.nl", $configuration->issuer);
-        $this->assertSame("https://provider.rdobeheer.nl/authorize", $configuration->authorizationEndpoint);
-        $this->assertSame("https://provider.rdobeheer.nl/jwks", $configuration->jwksUri);
-        $this->assertSame("https://provider.rdobeheer.nl/token", $configuration->tokenEndpoint);
-        $this->assertSame("https://provider.rdobeheer.nl/userinfo", $configuration->userinfoEndpoint);
+        $this->assertSame("https://provider.example.com", $configuration->issuer);
+        $this->assertSame("https://provider.example.com/authorize", $configuration->authorizationEndpoint);
+        $this->assertSame("https://provider.example.com/jwks", $configuration->jwksUri);
+        $this->assertSame("https://provider.example.com/token", $configuration->tokenEndpoint);
+        $this->assertSame("https://provider.example.com/userinfo", $configuration->userinfoEndpoint);
     }
 
     protected function fakeSuccessfulResponse(): void
     {
         Http::fake([
-            'https://provider.rdobeheer.nl/.well-known/openid-configuration' => Http::response([
+            'https://provider.example.com/.well-known/openid-configuration' => Http::response([
                 "version" => "3.0",
                 "token_endpoint_auth_methods_supported" => [
                     "none"
@@ -242,10 +242,10 @@ class OpenIDConfigurationLoaderTest extends TestCase
                 "frontchannel_logout_session_supported" => false,
                 "backchannel_logout_supported" => false,
                 "backchannel_logout_session_supported" => false,
-                "issuer" => "https://provider.rdobeheer.nl",
-                "authorization_endpoint" => "https://provider.rdobeheer.nl/authorize",
-                "jwks_uri" => "https://provider.rdobeheer.nl/jwks",
-                "token_endpoint" => "https://provider.rdobeheer.nl/token",
+                "issuer" => "https://provider.example.com",
+                "authorization_endpoint" => "https://provider.example.com/authorize",
+                "jwks_uri" => "https://provider.example.com/jwks",
+                "token_endpoint" => "https://provider.example.com/token",
                 "scopes_supported" => [
                     "openid"
                 ],
@@ -258,7 +258,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
                 "subject_types_supported" => [
                     "pairwise"
                 ],
-                "userinfo_endpoint" => "https://provider.rdobeheer.nl/userinfo",
+                "userinfo_endpoint" => "https://provider.example.com/userinfo",
                 "id_token_signing_alg_values_supported" => [
                     "RS256"
                 ],
@@ -272,7 +272,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
     protected function fakeInvalidResponse(int $statusCode, array|null|string $body): void
     {
         Http::fake([
-            'https://provider.rdobeheer.nl/*' => Http::response($body, $statusCode),
+            'https://provider.example.com/*' => Http::response($body, $statusCode),
         ]);
     }
 }


### PR DESCRIPTION
Since https://github.com/jumbojett/OpenID-Connect-PHP/releases/tag/v1.0.2 this overloading is not needed anymore.

Visibility changes of the properties:
https://github.com/jumbojett/OpenID-Connect-PHP/pull/433
https://github.com/jumbojett/OpenID-Connect-PHP/pull/446

Waiting for new release of https://github.com/jumbojett/OpenID-Connect-PHP.