### PR TITLE
Add generateInsecureOpenSSLKey function for testing

### DIFF
--- a/tests/Feature/Http/Controllers/LoginControllerResponseTest.php
+++ b/tests/Feature/Http/Controllers/LoginControllerResponseTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 use function MinVWS\OpenIDConnectLaravel\Tests\{
     generateJwt,
-    generateOpenSSLKey,
+    generateInsecureOpenSSLKey,
 };
 
 class LoginControllerResponseTest extends TestCase
@@ -530,7 +530,7 @@ class LoginControllerResponseTest extends TestCase
         Config::set('oidc.client_id', 'test-client-id');
 
         // Set client private key
-        [$key, $keyResource] = generateOpenSSLKey();
+        [$key, $keyResource] = generateInsecureOpenSSLKey();
         Config::set('oidc.client_authentication.signing_private_key_path', stream_get_meta_data($keyResource)['uri']);
 
         // Set the current state, which is usually generated and saved in the session before login,

--- a/tests/Feature/JweDecryptInterfaceBindingTest.php
+++ b/tests/Feature/JweDecryptInterfaceBindingTest.php
@@ -10,7 +10,7 @@ use MinVWS\OpenIDConnectLaravel\Tests\TestCase;
 use OpenSSLCertificate;
 
 use function MinVWS\OpenIDConnectLaravel\Tests\{
-    generateOpenSSLKey,
+    generateInsecureOpenSSLKey,
     generateX509Certificate,
     buildJweString,
     buildExamplePayload
@@ -27,7 +27,7 @@ class JweDecryptInterfaceBindingTest extends TestCase
 
     public function setUp(): void
     {
-        [$key, $keyResource] = generateOpenSSLKey();
+        [$key, $keyResource] = generateInsecureOpenSSLKey();
         $this->decryptionKeyResource = $keyResource;
         $this->recipient = generateX509Certificate($key);
 

--- a/tests/TestFunctions.php
+++ b/tests/TestFunctions.php
@@ -60,9 +60,22 @@ function buildExamplePayload(): string
 
 /**
  * Generate OpenSSL Key and return the tempfile resource
+ *
+ * Warning: This function generates a key with 512 bits, which is considered insecure.
+ * This is only for testing purposes.
+ *
  * @return array{OpenSSLAsymmetricKey, resource}
  */
-function generateOpenSSLKey(): array
+function generateInsecureOpenSSLKey(): array
+{
+    return generateOpenSSLKey(bits: 512);
+}
+
+/**
+ * Generate OpenSSL Key and return the tempfile resource
+ * @return array{OpenSSLAsymmetricKey, resource}
+ */
+function generateOpenSSLKey(int $bits = 2048): array
 {
     $file = tmpfile();
     if (!is_resource($file)) {
@@ -70,7 +83,7 @@ function generateOpenSSLKey(): array
     }
 
     $key = openssl_pkey_new([
-        'private_key_bits' => 512,
+        'private_key_bits' => $bits,
         'private_key_type' => OPENSSL_KEYTYPE_RSA,
     ]);
     if (!$key instanceof OpenSSLAsymmetricKey) {

--- a/tests/Unit/Services/JWE/JweDecryptServiceTest.php
+++ b/tests/Unit/Services/JWE/JweDecryptServiceTest.php
@@ -17,7 +17,7 @@ use OpenSSLCertificate;
 use PHPUnit\Framework\TestCase;
 
 use function MinVWS\OpenIDConnectLaravel\Tests\{
-    generateOpenSSLKey,
+    generateInsecureOpenSSLKey,
     generateX509Certificate,
     getJwkFromResource,
     buildJweString,
@@ -37,7 +37,7 @@ class JweDecryptServiceTest extends TestCase
     {
         parent::setUp();
 
-        [$key, $keyResource] = generateOpenSSLKey();
+        [$key, $keyResource] = generateInsecureOpenSSLKey();
         $this->decryptionKeyResource = $keyResource;
 
         $this->decryptionKeySet = new JWKSet([
@@ -92,7 +92,7 @@ class JweDecryptServiceTest extends TestCase
         $this->expectExceptionMessage('Failed to decrypt JWE');
 
         // Create different key
-        [$key, $keyResource] = generateOpenSSLKey();
+        [$key, $keyResource] = generateInsecureOpenSSLKey();
         $jwk = getJwkFromResource($keyResource);
         $decryptionKeySet = new JWKSet([$jwk]);
 
@@ -149,10 +149,10 @@ class JweDecryptServiceTest extends TestCase
      */
     public function testJweDecryptionWithMultipleKeysInKeySet(): void
     {
-        [$firstRecipientKey, $firstRecipientKeyResource] = generateOpenSSLKey();
+        [$firstRecipientKey, $firstRecipientKeyResource] = generateInsecureOpenSSLKey();
         $firstRecipient = generateX509Certificate($firstRecipientKey);
 
-        [$secondRecipientKey, $secondRecipientKeyResource] = generateOpenSSLKey();
+        [$secondRecipientKey, $secondRecipientKeyResource] = generateInsecureOpenSSLKey();
         $secondRecipient = generateX509Certificate($secondRecipientKey);
 
         $payload = buildExamplePayload();

--- a/tests/Unit/Services/JWS/PrivateKeyJWTBuilderTest.php
+++ b/tests/Unit/Services/JWS/PrivateKeyJWTBuilderTest.php
@@ -20,7 +20,7 @@ use OpenSSLAsymmetricKey;
 use PHPUnit\Framework\TestCase;
 
 use function MinVWS\OpenIDConnectLaravel\Tests\{
-    generateOpenSSLKey,
+    generateInsecureOpenSSLKey,
     getJwkFromResource,
 };
 
@@ -38,7 +38,7 @@ class PrivateKeyJWTBuilderTest extends TestCase
     {
         parent::setUp();
 
-        [$privateKey, $privateKeyResource] = generateOpenSSLKey();
+        [$privateKey, $privateKeyResource] = generateInsecureOpenSSLKey();
 
         $this->privateKey = $privateKey;
         $this->privateKeyResource = $privateKeyResource;


### PR DESCRIPTION
This function is used for testing purposes and is not meant to be secure, updated function name and description to be clear.

Updated the `generateOpenSSLKey` function to be "more secure" by default.

Fixes https://github.com/minvws/nl-rdo-openid-connect-php-laravel/issues/49.