### PR TITLE
Only run sonarcloud for latest supported PHP version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       tags: [ v* ]
     pull_request:
 
+env:
+  LATEST_SUPPORTED_PHP_VERSION: 8.4
+
 jobs:
     run-tests:
         runs-on: ubuntu-24.04
@@ -74,8 +77,9 @@ jobs:
 
             - name: Coding style PSR12 Check
               run: vendor/bin/phpcs
-            
+
             - name: 'Run SonarQube cloud scanner'
+              if: ${{ matrix.php == env.LATEST_SUPPORTED_PHP_VERSION }}
               uses: minvws/nl-irealisatie-generic-pipelines/.github/actions/sonarcloud@main
               with:
                 sonar-token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This fixes issues that the sonarcloud results are pushed at the same time. Only 1 result is needed.

We can debate on if we want this on the first supported version or the last.