### PR TITLE
add endSessionEndpoint to configuration to support ending the session

### DIFF
--- a/src/OpenIDConfiguration/OpenIDConfiguration.php
+++ b/src/OpenIDConfiguration/OpenIDConfiguration.php
@@ -58,6 +58,7 @@ class OpenIDConfiguration
         public array $idTokenSigningAlgValuesSupported = [],
         public string $userinfoEndpoint = '',
         public array $codeChallengeMethodsSupported = [],
+        public string $endSessionEndpoint = '',
     ) {
     }
 }

--- a/src/OpenIDConfiguration/OpenIDConfigurationLoader.php
+++ b/src/OpenIDConfiguration/OpenIDConfigurationLoader.php
@@ -91,7 +91,8 @@ class OpenIDConfigurationLoader
             subjectTypesSupported: $response->json('subject_types_supported', []),
             idTokenSigningAlgValuesSupported: $response->json('id_token_signing_alg_values_supported', []),
             userinfoEndpoint: $response->json('userinfo_endpoint', ''),
-            codeChallengeMethodsSupported: $response->json('code_challenge_methods_supported', [])
+            codeChallengeMethodsSupported: $response->json('code_challenge_methods_supported', []),
+            endSessionEndpoint: $response->json('end_session_endpoint', ''),
         );
     }
 

--- a/tests/Feature/Http/Controllers/LoginControllerResponseTest.php
+++ b/tests/Feature/Http/Controllers/LoginControllerResponseTest.php
@@ -620,6 +620,7 @@ class LoginControllerResponseTest extends TestCase
             idTokenSigningAlgValuesSupported: ["RS256"],
             userinfoEndpoint: "https://provider.example.com/userinfo",
             codeChallengeMethodsSupported: $codeChallengeMethodsSupported,
+            endSessionEndpoint: "https://provider.example.com/endSession",
         );
     }
 

--- a/tests/Feature/Http/Controllers/LoginControllerTest.php
+++ b/tests/Feature/Http/Controllers/LoginControllerTest.php
@@ -149,6 +149,7 @@ class LoginControllerTest extends TestCase
             idTokenSigningAlgValuesSupported: ["RS256"],
             userinfoEndpoint: "https://provider.example.com/userinfo",
             codeChallengeMethodsSupported: ["S256"],
+            endSessionEndpoint: "https://provider.example.com/endSession",
         );
     }
 }

--- a/tests/Feature/OpenIDConfiguration/OpenIDConfigurationLoaderTest.php
+++ b/tests/Feature/OpenIDConfiguration/OpenIDConfigurationLoaderTest.php
@@ -38,6 +38,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
         $this->assertSame("https://provider.example.com/jwks", $configuration->jwksUri);
         $this->assertSame("https://provider.example.com/token", $configuration->tokenEndpoint);
         $this->assertSame("https://provider.example.com/userinfo", $configuration->userinfoEndpoint);
+        $this->assertSame("https://provider.example.com/logout", $configuration->endSessionEndpoint);
     }
 
     public function testConfigurationIsLoadedMultipleTimesWhenNotCached(): void
@@ -60,6 +61,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
         $this->assertSame("https://provider.example.com/jwks", $configuration->jwksUri);
         $this->assertSame("https://provider.example.com/token", $configuration->tokenEndpoint);
         $this->assertSame("https://provider.example.com/userinfo", $configuration->userinfoEndpoint);
+        $this->assertSame("https://provider.example.com/logout", $configuration->endSessionEndpoint);
     }
 
     public function testConfigurationIsCached(): void
@@ -87,6 +89,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
         $this->assertSame("https://provider.example.com/jwks", $configuration->jwksUri);
         $this->assertSame("https://provider.example.com/token", $configuration->tokenEndpoint);
         $this->assertSame("https://provider.example.com/userinfo", $configuration->userinfoEndpoint);
+        $this->assertSame("https://provider.example.com/logout", $configuration->endSessionEndpoint);
     }
 
     public function testLoaderThrowsExceptionWhenProviderReturns400ResponseCode(): void
@@ -198,6 +201,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
         $this->assertEmpty($configuration->authorizationEndpoint);
         $this->assertEmpty($configuration->jwksUri);
         $this->assertEmpty($configuration->tokenEndpoint);
+        $this->assertEmpty($configuration->userinfoEndpoint);
     }
 
     public function testConfigurationIsLoadedMultipleTimesWhenCacheStoreIsNull(): void
@@ -221,6 +225,7 @@ class OpenIDConfigurationLoaderTest extends TestCase
         $this->assertSame("https://provider.example.com/jwks", $configuration->jwksUri);
         $this->assertSame("https://provider.example.com/token", $configuration->tokenEndpoint);
         $this->assertSame("https://provider.example.com/userinfo", $configuration->userinfoEndpoint);
+        $this->assertSame("https://provider.example.com/logout", $configuration->endSessionEndpoint);
     }
 
     protected function fakeSuccessfulResponse(): void
@@ -264,7 +269,8 @@ class OpenIDConfigurationLoaderTest extends TestCase
                 ],
                 "code_challenge_methods_supported" => [
                     "S256"
-                ]
+                ],
+                "end_session_endpoint" => "https://provider.example.com/logout"
             ])
         ]);
     }

--- a/tests/Feature/OpenIDConnectClientTest.php
+++ b/tests/Feature/OpenIDConnectClientTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MinVWS\OpenIDConnectLaravel\Tests\Feature;
+
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use MinVWS\OpenIDConnectLaravel\OpenIDConnectClient;
+use MinVWS\OpenIDConnectLaravel\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class OpenIDConnectClientTest extends TestCase
+{
+    public function testSignOut(): void
+    {
+        Http::fake([
+            'https://provider.example.com/.well-known/openid-configuration' => Http::response([
+                "end_session_endpoint" => "https://provider.example.com/logout",
+            ])
+        ]);
+        Config::set('oidc.issuer', 'https://provider.example.com');
+        Config::set('oidc.configuration_cache.store', null);
+
+        $client = app(OpenIDConnectClient::class);
+
+        try {
+            $client->signOut('idToken', 'redirect');
+        } catch (HttpResponseException $e) {
+            $this->assertEquals(Response::HTTP_FOUND, $e->getResponse()->getStatusCode());
+            $this->assertEquals(
+                'https://provider.example.com/logout?id_token_hint=idToken&post_logout_redirect_uri=redirect',
+                $e->getResponse()->getTargetUrl()
+            );
+
+            return;
+        }
+    }
+}


### PR DESCRIPTION
The openid package that this package uses "jumbojett/openid-connect-php" has a signout functionality to end the session on the remote server: https://github.com/jumbojett/OpenID-Connect-PHP/blob/master/src/OpenIDConnectClient.php#L435

See https://openid.net/specs/openid-connect-session-1_0-17.html#rfc.section.2.1

This is not working when using this package because the end session url from the well known config is not loaded.

This MR fixes that and makes it possible to use the signout functionality.