### PR TITLE
feat: add Laravel 13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ 8.1, 8.2, 8.3, 8.4 ]
-                laravel: [ 10.*, 11.*, 12.* ]
+                php: [ 8.2, 8.3, 8.4 ]
+                laravel: [ 10.*, 11.*, 12.*, 13.* ]
                 stability: [ prefer-stable ]
                 experimental: [ false ]
                 include:
@@ -30,11 +30,11 @@ jobs:
                     testbench: 9.*
                   - laravel: 12.*
                     testbench: 10.*
+                  - laravel: 13.*
+                    testbench: 11.*
                 exclude:
-                  - php: 8.1
-                    laravel: 11.*
-                  - php: 8.1
-                    laravel: 12.*
+                  - php: 8.2
+                    laravel: 13.*
 
 
         name: PHP ${{ matrix.php }} - L${{ matrix.laravel }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This package is an OpenID Connect implementation for Laravel, based on the [jumb
 ## Requirements
 Before using the OpenID Connect package for Laravel, ensure that your development environment meets the following requirements:
 
-- PHP 8.1 or higher: The package requires at least PHP version 8.1. Make sure you have PHP installed and configured properly on your system.
+- PHP 8.2 or higher: The package requires at least PHP version 8.2. Make sure you have PHP installed and configured properly on your system.
 - Laravel: The package is designed to work with Laravel, so you should have a Laravel application set up and running.
 - Composer: Composer is a dependency manager for PHP. You will need Composer installed to install and manage the package and its dependencies.
 - **Recommended:** For optimal cryptographic performance (especially for RSA operations), it is highly recommended to enable the [GMP](https://www.php.net/manual/en/book.gmp.php) or [BCMath](https://www.php.net/manual/en/book.bc.php) PHP extensions. These extensions significantly improve the speed of cryptographic operations used by the underlying JWT library.

--- a/composer.json
+++ b/composer.json
@@ -30,14 +30,14 @@
         }
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "jumbojett/openid-connect-php": "^1.0.2",
         "guzzlehttp/guzzle": "^7.5",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
-        "web-token/jwt-library": "^3.4"
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",
+        "web-token/jwt-library": "^4.1"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0||^9.0||^10.0",
+        "orchestra/testbench": "^8.0||^9.0||^10.0||^11.0",
         "phpunit/phpunit": "^10.0||^11.0||^12.0",
         "vimeo/psalm": "^5.8||^6.0",
         "phpstan/phpstan": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "orchestra/testbench": "^8.0||^9.0||^10.0||^11.0",
         "phpunit/phpunit": "^10.0||^11.0||^12.0",
         "vimeo/psalm": "^5.8||^6.0",
-        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan": "^2",
         "squizlabs/php_codesniffer": "^3.8",
         "slevomat/coding-standard": "^8.14",
         "ext-openssl": "*"
@@ -65,6 +65,9 @@
         "lock": false,
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "audit": {
+            "block-insecure": false
         }
     }
 }

--- a/src/Services/JWE/JweDecryptService.php
+++ b/src/Services/JWE/JweDecryptService.php
@@ -8,26 +8,15 @@ use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Encryption\Algorithm\ContentEncryption\A128CBCHS256;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\RSAOAEP;
-use Jose\Component\Encryption\Compression\CompressionMethodManager;
-use Jose\Component\Encryption\Compression\Deflate;
 use Jose\Component\Encryption\JWEDecrypter;
-use Jose\Component\Encryption\Serializer\CompactSerializer;
-use Jose\Component\Encryption\Serializer\JWESerializerManager;
 
 class JweDecryptService implements JweDecryptInterface
 {
-    /**
-     * @param JWKSet $decryptionKeySet
-     * @param JWESerializerManager $serializerManager
-     * @param JWEDecrypter $jweDecrypter
-     */
     public function __construct(
         protected JWKSet $decryptionKeySet,
-        protected JWESerializerManager $serializerManager = new JWESerializerManager([new CompactSerializer()]),
+        protected JweSerializerManagerInterface $serializerManager = new NativeJweSerializerManager(),
         protected JWEDecrypter $jweDecrypter = new JWEDecrypter(
-            new AlgorithmManager([new RSAOAEP()]),
-            new AlgorithmManager([new A128CBCHS256()]),
-            new CompressionMethodManager([new Deflate()])
+            new AlgorithmManager([new RSAOAEP(), new A128CBCHS256()])
         ),
     ) {
     }

--- a/src/Services/JWE/JweSerializerManagerInterface.php
+++ b/src/Services/JWE/JweSerializerManagerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MinVWS\OpenIDConnectLaravel\Services\JWE;
+
+use Jose\Component\Encryption\JWE;
+
+interface JweSerializerManagerInterface
+{
+    public function unserialize(string $input): JWE;
+}

--- a/src/Services/JWE/NativeJweSerializerManager.php
+++ b/src/Services/JWE/NativeJweSerializerManager.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MinVWS\OpenIDConnectLaravel\Services\JWE;
+
+use Jose\Component\Encryption\JWE;
+use Jose\Component\Encryption\Serializer\CompactSerializer;
+use Jose\Component\Encryption\Serializer\JWESerializerManager;
+
+final class NativeJweSerializerManager implements JweSerializerManagerInterface
+{
+    public function __construct(
+        private JWESerializerManager $manager = new JWESerializerManager([new CompactSerializer()]),
+    ) {
+    }
+
+    #[\Override]
+    public function unserialize(string $input): JWE
+    {
+        return $this->manager->unserialize($input);
+    }
+}

--- a/tests/TestFunctions.php
+++ b/tests/TestFunctions.php
@@ -8,8 +8,6 @@ use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\Encryption\Algorithm\ContentEncryption\A128CBCHS256;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\RSAOAEP;
-use Jose\Component\Encryption\Compression\CompressionMethodManager;
-use Jose\Component\Encryption\Compression\Deflate;
 use Jose\Component\Encryption\JWEBuilder;
 use Jose\Component\Encryption\Serializer\CompactSerializer;
 use Jose\Component\KeyManagement\JWKFactory;
@@ -23,9 +21,7 @@ function buildJweString(string $payload, JWK $recipient): string
 {
     // Create the JWE builder object
     $jweBuilder = new JWEBuilder(
-        new AlgorithmManager([new RSAOAEP()]),
-        new AlgorithmManager([new A128CBCHS256()]),
-        new CompressionMethodManager([new Deflate()])
+        new AlgorithmManager([new RSAOAEP(), new A128CBCHS256()])
     );
 
     // Build the JWE
@@ -35,7 +31,6 @@ function buildJweString(string $payload, JWK $recipient): string
         ->withSharedProtectedHeader([
             'alg' => 'RSA-OAEP',
             'enc' => 'A128CBC-HS256',
-            'zip' => 'DEF',
         ])
         ->addRecipient($recipient)
         ->build();

--- a/tests/Unit/Services/JWE/JweDecryptServiceTest.php
+++ b/tests/Unit/Services/JWE/JweDecryptServiceTest.php
@@ -7,7 +7,7 @@ namespace MinVWS\OpenIDConnectLaravel\Tests\Unit\Services\JWE;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\Encryption\JWE;
 use Jose\Component\Encryption\JWEDecrypter;
-use Jose\Component\Encryption\Serializer\JWESerializerManager;
+use MinVWS\OpenIDConnectLaravel\Services\JWE\JweSerializerManagerInterface;
 use Jose\Component\KeyManagement\JWKFactory;
 use JsonException;
 use MinVWS\OpenIDConnectLaravel\Services\JWE\JweDecryptException;
@@ -123,7 +123,7 @@ class JweDecryptServiceTest extends TestCase
             ->andReturn(null);
 
         $decryptionKeySet = Mockery::mock(JWKSet::class);
-        $serializerManager = Mockery::mock(JWESerializerManager::class);
+        $serializerManager = Mockery::mock(JweSerializerManagerInterface::class);
         $serializerManager
             ->shouldReceive('unserialize')
             ->with('something')

--- a/tests/Unit/Services/JWS/PrivateKeyJWTBuilderTest.php
+++ b/tests/Unit/Services/JWS/PrivateKeyJWTBuilderTest.php
@@ -7,14 +7,11 @@ namespace MinVWS\OpenIDConnectLaravel\Tests\Unit\Services\JWS;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\KeyManagement\JWKFactory;
 use Jose\Component\Signature\Algorithm\RS256;
-use Jose\Component\Signature\JWS;
 use Jose\Component\Signature\JWSBuilder;
 use Jose\Component\Signature\JWSVerifier;
 use Jose\Component\Signature\Serializer\CompactSerializer;
 use Jose\Component\Signature\Serializer\JWSSerializerManager;
-use Jose\Component\Signature\Serializer\Serializer;
 use MinVWS\OpenIDConnectLaravel\Services\JWS\PrivateKeyJWTBuilder;
-use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use OpenSSLAsymmetricKey;
 use PHPUnit\Framework\TestCase;
@@ -60,37 +57,19 @@ class PrivateKeyJWTBuilderTest extends TestCase
 
     public function testPayload(): void
     {
-        $mockSerializer = Mockery::mock(Serializer::class);
-        $mockSerializer
-            ->shouldReceive('serialize')
-            ->withArgs(function ($jws, $index) {
-                /** @var JWS $jws */
-                $this->assertInstanceOf(JWS::class, $jws);
-                $this->assertSame(0, $index);
+        $jws = $this->generateJws('client_id', 'audience');
 
-                $payload = json_decode($jws->getPayload(), true);
+        $serializerManager = new JWSSerializerManager([
+            new CompactSerializer(),
+        ]);
+        $payload = json_decode($serializerManager->unserialize($jws)->getPayload(), true);
 
-                $iat = $payload['iat'];
-                $this->assertSame($iat + $this->tokenLifetimeInSeconds, $payload['exp']);
-
-                $this->assertSame('client_id', $payload['iss']);
-                $this->assertSame('client_id', $payload['sub']);
-                $this->assertSame('audience', $payload['aud']);
-                $this->assertNotEmpty($payload['jti']);
-
-                return true;
-            });
-
-        $builder = new PrivateKeyJWTBuilder(
-            'client_id',
-            new JWSBuilder($this->algorithmManager),
-            getJwkFromResource($this->privateKeyResource),
-            'RS256',
-            $mockSerializer,
-            $this->tokenLifetimeInSeconds,
-        );
-
-        $builder->__invoke('audience');
+        $iat = $payload['iat'];
+        $this->assertSame($iat + $this->tokenLifetimeInSeconds, $payload['exp']);
+        $this->assertSame('client_id', $payload['iss']);
+        $this->assertSame('client_id', $payload['sub']);
+        $this->assertSame('audience', $payload['aud']);
+        $this->assertNotEmpty($payload['jti']);
     }
 
     public function testSignature(): void


### PR DESCRIPTION
### What's changed?
- Upgraded `jwt-library` to `v4`. 
`Laravel 13` require `brick/math ^0.14.2`, which is incompatible with `web-token/jwt-library v3`.
- Added `illuminate/contracts ^13.0` and `orchestra/testbench ^11.0`.
- Bumped minimum `PHP` to `8.2`
- Extended CI to cover `Laravel 13`.

### Laravel 10 & 11 — composer update fails
Recent Composer versions block packages with open security advisories. 
Every installable Laravel 10/11 release is flagged, so dependency installation failed before tests could run.
It is fixed by disabling advisory blocking in `composer.json` so CI can still test against those supported versions:

```json
"audit": {
    "block-insecure": false
}
```

### Laravel 13 - PHPStan errors
`PHPStan 1.x` cannot parse `Symfony 8` (bundled with `Laravel 13`), so it reports `Symfony\Component\HttpFoundation\Response` as not found.
It is fixed by upgrading `PHPStan` to `^2`, which handles `Symfony 8` correctly.

### PHP minimum version: 8.1 → 8.2
The minimum PHP version is raised from >=8.1 to >=8.2 as part of adding Laravel 13 support and upgrading web-token/jwt-library to v4.

Laravel 13 depends on brick/math ^0.14.2, which is incompatible with web-token/jwt-library v3. 
Upgrading to jwt-library v4 resolves that, but v4 requires PHP 8.2+.

#### What this means for consumers
The only scenario that loses support is Laravel 10 on PHP 8.1.

Keeping PHP 8.1 would mean maintaining two `jwt-library` major versions (`v3` for `Laravel 10` / `PHP 8.1`, `v4` for `Laravel 13+`), with adds extra complexity. Given `Laravel 11+` and `jwt-library v4` both require `8.2+`, I think raising the minimum is the simpler and more maintainable choice.

